### PR TITLE
fix(client): remove jQuery from print window

### DIFF
--- a/client/assets/js/Controller/Editor.js
+++ b/client/assets/js/Controller/Editor.js
@@ -354,7 +354,6 @@ EditorController.prototype.print = function(){
   var numbered_text = lines.join('\n');
   $('#print_content .with_line_numbers').text(numbered_text);
   $('#print_content .without_line_numbers').text(this.editor_view.getValue());
-  myWindow.document.write("<script src='https://code.jquery.com/jquery-1.11.3.min.js'></script>");
   myWindow.document.write($('#print_content').html());
 }
 

--- a/client/print.tt
+++ b/client/print.tt
@@ -11,20 +11,19 @@
   <pre class="without_line_numbers"></pre>
 
   <script>
-    $('#print').click(function(){
+    document.getElementById('print').addEventListener('click', function(){
       window.print()
     });
 
-    var line_numbers_on = false;
-    $('#line_numbers_checkbox').change( function(){
-      line_numbers_on = !line_numbers_on;
-      if(line_numbers_on) {
-        $('.without_line_numbers').addClass('hide')
-        $('.with_line_numbers').removeClass('hide')
+    var line_numbers_checkbox = document.getElementById('line_numbers_checkbox');
+    line_numbers_checkbox.addEventListener('change', function(){
+      if(line_numbers_checkbox.checked) {
+        document.querySelector('.without_line_numbers').classList.add('hide')
+        document.querySelector('.with_line_numbers').classList.remove('hide')
       }
-      else { 
-        $('.without_line_numbers').removeClass('hide')
-        $('.with_line_numbers').addClass('hide')
+      else {
+        document.querySelector('.without_line_numbers').classList.remove('hide')
+        document.querySelector('.with_line_numbers').classList.add('hide')
       }
     });
   </script>

--- a/client/tests/print-source-check.js
+++ b/client/tests/print-source-check.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+
+function readSource(relativePath) {
+  return fs.readFileSync(path.join(__dirname, '..', relativePath), 'utf8');
+}
+
+var template = readSource('print.tt');
+var editor = readSource('assets/js/Controller/Editor.js');
+
+assert.ok(template.indexOf("<a id=\"print\" href=\"#print\" class=\"btn btn-primary\">Print</a>") !== -1);
+assert.ok(template.indexOf("<label for=\"line_numbers_checkbox\">Line numbers : </label>") !== -1);
+assert.ok(template.indexOf("<pre class=\"with_line_numbers hide\"></pre>") !== -1);
+assert.ok(template.indexOf("<pre class=\"without_line_numbers\"></pre>") !== -1);
+assert.ok(template.indexOf("document.getElementById('print').addEventListener('click'") !== -1);
+assert.ok(template.indexOf("document.getElementById('line_numbers_checkbox')") !== -1);
+assert.ok(template.indexOf("addEventListener('change'") !== -1);
+assert.ok(template.indexOf('line_numbers_checkbox.checked') !== -1);
+assert.ok(template.indexOf(".without_line_numbers').classList.add('hide')") !== -1);
+assert.ok(template.indexOf(".without_line_numbers').classList.remove('hide')") !== -1);
+assert.ok(template.indexOf(".with_line_numbers').classList.add('hide')") !== -1);
+assert.ok(template.indexOf(".with_line_numbers').classList.remove('hide')") !== -1);
+assert.ok(template.indexOf('line_numbers_on') === -1);
+assert.ok(template.indexOf('$') === -1);
+assert.ok(template.indexOf('window.print()') !== -1);
+
+assert.ok(editor.indexOf('jquery-1.11.3.min.js') === -1);
+assert.ok(editor.indexOf('var myWindow = window.open("", "MsgWindow", "width=800, height=600");') !== -1);
+assert.ok(editor.indexOf("$('#print_content .with_line_numbers').text(numbered_text);") !== -1);
+assert.ok(editor.indexOf("$('#print_content .without_line_numbers').text(this.editor_view.getValue());") !== -1);
+assert.ok(editor.indexOf("myWindow.document.write($('#print_content').html());") !== -1);
+
+console.log('print source check passed');


### PR DESCRIPTION
## Summary
- replace the print window's two jQuery event handlers with native DOM APIs
- derive line-number visibility from the checkbox state
- remove the print-only jQuery 1.11.3 CDN injection
- keep the main application's jQuery text writes and print layout unchanged

## Validation
- `node client/tests/print-source-check.js`
- `bash -n client/afn-app.sh`

Browser print-preview and both deployed app variants still need the approved runtime smoke check; no application dependency or build-pipeline change is included.